### PR TITLE
jobs and logs grouping by original job id

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -102,19 +102,13 @@ class DefaultController extends Controller
      */
     public function listFailedAction(Request $request)
     {
-        list($start, $count, $showingAll) = $this->getShowParameters($request);
-
-        $jobs = $this->getResque()->getFailedJobs($start, $count);
-
-        if (!$showingAll) {
-            $jobs = array_reverse($jobs);
-        }
+        $jobs = $this->getResque()->getFailedJobs();
 
         return $this->render(
             'ResqueBundle:Default:failed_list.html.twig',
             [
                 'jobs'       => $jobs,
-                'showingAll' => $showingAll,
+                'showingAll' => true,
             ]
         );
     }
@@ -170,9 +164,10 @@ class DefaultController extends Controller
     /**
      * @return RedirectResponse
      */
-    public function retryFailedAction()
+    public function retryFailedAction(Request $request)
     {
-        $count = $this->getResque()->retryFailedJobs();
+        $id = $request->get('id', null);
+        $count = $this->getResque()->retryFailedJobs($id);
 
         $this->addFlash('info', 'Retry '.$count.' failed jobs.');
 
@@ -182,9 +177,10 @@ class DefaultController extends Controller
     /**
      * @return RedirectResponse
      */
-    public function retryClearFailedAction()
+    public function retryClearFailedAction(Request $request)
     {
-        $count = $this->getResque()->retryFailedJobs(true);
+        $id = $request->get('id', null);
+        $count = $this->getResque()->retryFailedJobs($id, true);
 
         $this->addFlash('info', 'Retry and clear '.$count.' failed jobs.');
 
@@ -194,12 +190,27 @@ class DefaultController extends Controller
     /**
      * @return RedirectResponse
      */
-    public function clearFailedAction()
+    public function clearFailedAction(Request $request)
     {
-        $count = $this->getResque()->clearFailedJobs();
+        $id = $request->get('id', null);
+        $count = $this->getResque()->clearFailedJobs($id);
 
         $this->addFlash('info', 'Clear '.$count.' failed jobs.');
 
         return $this->redirectToRoute('ResqueBundle_homepage');
     }
+
+    /**
+     * @return RedirectResponse
+     */
+    public function clearScheduledAction(Request $request)
+    {
+        $id = $request->get('id', null);
+        $count = $this->getResque()->clearScheduled($id);
+
+        $this->addFlash('info', 'Clear '.$count.' scheduled jobs.');
+
+        return $this->redirectToRoute('ResqueBundle_homepage');
+    }
+
 }

--- a/FailedJob.php
+++ b/FailedJob.php
@@ -46,6 +46,30 @@ class FailedJob
     }
 
     /**
+     * @return int
+     */
+    public function getParentId()
+    {
+        $args = $this->getArgs();
+        if ($args && count($args) && isset($args[0]['resque.parent_id'])) {
+            return $args[0]['resque.parent_id'];
+        }
+        return null;
+    }
+
+    /**
+     * @return int
+     */
+    public function getParentIdOrId()
+    {
+        $args = $this->getArgs();
+        if ($args && count($args) && isset($args[0]['resque.parent_id'])) {
+            return $args[0]['resque.parent_id'];
+        }
+        return $this->getId();
+    }
+
+    /**
      * @return string
      */
     public function getQueueName()
@@ -92,4 +116,17 @@ class FailedJob
     {
         return $this->data['payload']['args'];
     }
+
+    /**
+     * @return array
+     */
+    public function getRetryAttempt()
+    {
+        $args = $this->getArgs();
+        if ($args && count($args) && isset($args[0]['resque.retry_attempt'])) {
+            return (int) $args[0]['resque.retry_attempt'] + 1;
+        }
+        return 1;
+    }
+
 }

--- a/Failure.php
+++ b/Failure.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ResqueBundle\Resque;
+
+class Failure implements \Resque_Failure_Interface
+{
+    /**
+     * Initialize a failed job class and save it (where appropriate).
+     *
+     * @param object $payload Object containing details of the failed job.
+     * @param object $exception Instance of the exception that was thrown by the failed job.
+     * @param object $worker Instance of Resque_Worker that received the job.
+     * @param string $queue The name of the queue the job was fetched from.
+     */
+    public function __construct($payload, $exception, $worker, $queue)
+    {
+        $data = new \stdClass;
+        $data->failed_at = strftime('%a %b %d %H:%M:%S %Z %Y');
+        $data->payload = $payload;
+        $data->exception = get_class($exception);
+        $data->error = $exception->getMessage();
+        $data->backtrace = explode("\n", $exception->getTraceAsString());
+        $data->worker = (string)$worker;
+        $data->queue = $queue;
+        $data = json_encode($data);
+        \Resque::redis()->rpush('failed:'.$this->getParentIdOrId($payload), $data);
+    }
+
+    protected function getParentIdOrId($payload) {
+        $args = $payload['args'];
+        if ($args && count($args) && isset($args[0]['resque.parent_id'])) {
+            return $args[0]['resque.parent_id'];
+        } else {
+            return $payload['id'];
+        }
+    }
+}

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -32,6 +32,10 @@
         <default key="_controller">ResqueBundle:Default:clearFailed</default>
     </route>
 
+    <route id="ResqueBundle_scheduled_clear" path="/scheduled/clear">
+        <default key="_controller">ResqueBundle:Default:clearScheduled</default>
+    </route>
+
     <route id="ResqueBundle_workers" path="/workers">
         <default key="_controller">ResqueBundle:Default:workers</default>
     </route>

--- a/Resources/views/Default/failed_list.html.twig
+++ b/Resources/views/Default/failed_list.html.twig
@@ -11,9 +11,10 @@
             </span>
         </p>
         {% include "ResqueBundle:Default:_miniPager.html.twig" %}
-        <table class="table table-striped table-bordered">
+        <table class="table table-bordered">
             <thead>
                 <tr>
+                    <th>Id</th>
                     <th>Queue</th>
                     <th>Failed at</th>
                     <th>Job</th>
@@ -22,10 +23,22 @@
                 </tr>
             </thead>
             <tbody>
-                {% for job in jobs %}
+            {% for jobGroup in jobs %}
                 <tr>
-                    <td class="span1">{{ job.queueName }}</td>
-                    <td class="span2">{{ job.failedAt }}</td>
+                  <td colspan="6">
+                    {{ jobGroup.0.parentIdOrId }}
+                    <a class="btn btn-default btn-sm" href="{{ path('ResqueBundle_failed_retry',{'id': jobGroup.0.parentIdOrId}) }}">retry</a>
+                    <a class="btn btn-default btn-sm" href="{{ path('ResqueBundle_failed_clear',{'id': jobGroup.0.parentIdOrId}) }}">clear</a>
+                    <a class="btn btn-default btn-sm" href="{{ path('ResqueBundle_scheduled_clear',{'id': jobGroup.0.parentIdOrId}) }}">clear scheduled</a>
+                  </td>
+                </tr>
+                {% for job in jobGroup %}
+                <tr>
+                    {% if loop.index == 1 %}
+                        <td class="span1" rowspan="{{ jobGroup | length }}"></td>
+                    {% endif %}
+                    <td class="span2">{{ job.queueName }}</td>
+                    <td class="span3">#{{ job.retryAttempt }} {{ job.failedAt }}</td>
                     <td class="span4">{{ job.name }}</td>
                     <td class="span5">
                         {{ job.exceptionClass }}<br>
@@ -42,6 +55,8 @@
                         </div>
                         <div class="hide" id="{{ job.id }}_args">
                             <dl class="dl-horizontal">
+                                <dt>id</dt>
+                                <dd>{{ job.id }}</dd>
                                 {% for argname, argvalue in job.args.0 %}
                                     <dt>{{ argname }}</dt>
                                     <dd>{{ argvalue | json_encode(constant('JSON_PRETTY_PRINT')) }}</dd>
@@ -57,8 +72,10 @@
                     </td>
                 </tr>
                 {% endfor %}
+            {% endfor %}
 
-                    <div class="modal fade" id="strackTrace" tabindex="-1" role="dialog" aria-labelledby="strackTraceLabel">
+
+            <div class="modal fade" id="strackTrace" tabindex="-1" role="dialog" aria-labelledby="strackTraceLabel">
                         <div class="modal-dialog" role="document">
                             <div class="modal-content">
                                 <div class="modal-header">

--- a/bin/resque
+++ b/bin/resque
@@ -63,6 +63,8 @@ if (!empty($PREFIX)) {
     Resque_Redis::prefix($PREFIX);
 }
 
+Resque_Failure::setBackend(\ResqueBundle\Resque\Failure::class);
+
 // If set, re-attach failed jobs based on retry_strategy
 Resque_Event::listen('onFailure', function (Exception $exception, Resque_Job $job) use ($logger) {
     $args = $job->getArguments();
@@ -83,6 +85,14 @@ Resque_Event::listen('onFailure', function (Exception $exception, Resque_Job $jo
     $delay = $backoff[$args['resque.retry_attempt']];
     $args['resque.retry_attempt']++;
 
+    $id = $job->payload['id'];
+    $parentId = isset($args['resque.parent_id']) ? $args['resque.parent_id'] : null;
+    if ($parentId && $args['resque.retry_attempt'] > 0) {
+        $args['resque.parent_id'] = $parentId;
+    } else {
+        $args['resque.parent_id'] = $id;
+    }
+
     if ($delay == 0) {
         Resque::enqueue($job->queue, $job->payload['class'], $args);
         $logger->log(Psr\Log\LogLevel::ERROR, 'Job failed. Auto re-queued, attempt number: {attempt}', [
@@ -95,6 +105,17 @@ Resque_Event::listen('onFailure', function (Exception $exception, Resque_Job $jo
             'timestamp' => date('Y-m-d H:i:s', $at),
             'attempt'   => $args['resque.retry_attempt'] - 1,
         ]);
+    }
+});
+
+// If set, clear previously created failed logs
+Resque_Event::listen('afterPerform', function (Resque_Job $job) use ($logger) {
+    $args = $job->getArguments();
+    $id = $job->payload['id'];
+    $parentId = isset($args['resque.parent_id']) ? $args['resque.parent_id'] : null;
+    // Remove failed logs for completed job with auto retry
+    if ($parentId && $args['resque.retry_attempt'] > 0) {
+        Resque::redis()->del('failed:' . $parentId);
     }
 });
 


### PR DESCRIPTION
jobs are grouped by original job id
modified log list table - added job groups with statistic for each retry
previously created failed logs are cleared when job is completed
when retrying jobs by manual only original jobs are passed to queue